### PR TITLE
Update MAP-LIB_ProjectRules.md

### DIFF
--- a/MAP-LIB_ProjectRules.md
+++ b/MAP-LIB_ProjectRules.md
@@ -260,7 +260,7 @@ Members:
   | `Blocks`                     | Anton Haumer, Martin Otter                                      |
   | `Clocked`                    | Christoff Bürger, Bernhard Thiele                               |
   | `ComplexBlocks`              | Anton Haumer, Christian Kral                                    |
-  | `Blocks.Tables`              | Thomas Beutlich, Anton Haumer, Martin Otter                     |
+  | `Blocks.Tables`              | Thomas Beutlich, Hans Olsson, Martin Otter                     |
   | `StateGraph`                 | Hans Olsson, Martin Otter                                       |
   | `Electrical.Analog`          | Christoph Clauss, Anton Haumer, Christian Kral, Kristin Majetta |
   | `Electrical.Batteries`       | Anton Haumer, Christian Kral                                    |
@@ -277,7 +277,6 @@ Members:
   | `Mechanics.Rotational`       | Anton Haumer, Christian Kral, Martin Otter, Jakub Tobolar       |
   | `Mechanics.Translational`    | Anton Haumer, Christian Kral, Martin Otter, Jakub Tobolar       |
   | `Fluid`                      | Francesco Casella, Arunkumar Narashiman                         |
-  | `Fluid.Dissipation`          | Francesco Casella                                               |
   | `Media`                      | Francesco Casella, Arunkumar Narashiman                         |
   | `Thermal.FluidHeatFlow`      | Anton Haumer, Christian Kral                                    |
   | `Thermal.HeatTransfer`       | Anton Haumer, Christian Kral                                    |


### PR DESCRIPTION
Removed item for Fluid.Dissipation, since Stefan Wischhusen resigned last year, no need to have a separate sub-library officer. Decision at MAP-LIB meeting 2024-06-11 Toni resigns from Blocks.Tables, Hans replaces him