### PR TITLE
Update date of last library officers update

### DIFF
--- a/MAP-LIB_ProjectRules.md
+++ b/MAP-LIB_ProjectRules.md
@@ -252,7 +252,7 @@ Members:
   | Ziske, Johannes       | individual                                    |
 
 ## Annex 3: Library Officers ##
-*(2020-03-07)*
+*(2024-06-11)*
 
   | **Library**                  | **Library Officers** (alphabetically)                           |
   |------------------------------|-----------------------------------------------------------------|


### PR DESCRIPTION
The last change was made during the MAP-LIB meeting on 2024-06-11